### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "haskoy",
+  "version": "0.0.0",
+  "description": "Hasköy is a variable sans-serif typeface family. Designed with powerful opentype features and each weight includes latin-extended language support, stylistic alternates, fractions, tabular figures, arrows and more.",
+  "author": "Ertekin Erdin (https://ertekin.xyz)"
+}


### PR DESCRIPTION
Creating a package.json allow web developers (including me) to use The Hasköy font in Node.js applications, like React, using the following command: 

```
npm install ertekinno/haskoy
```